### PR TITLE
feat: scaffold ReadySetHire frontend with interview flow

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,0 +1,81 @@
+# Development Plan
+
+## Stage A Prompt
+- Objective: establish required docs/rules skeleton before coding.
+- Tasks: create directories per spec, add placeholder README, rules docs with rubric references, ensure no business logic yet.
+- Checks: directory structure matches PRD, docs include required sections, git status clean aside from expected files.
+
+
+### Stage A Completion
+- Created required directory skeleton under `src`, `public`, `docs`, and `rules`.
+- Authored rules and documentation files as specified.
+- TODO: None for this stage.
+
+## Stage B Prompt
+- Initialize Vite React project with TailwindCSS setup.
+- Configure routing with React Router, include global layout with header, footer, navigation placeholders.
+- Ensure ESLint/Prettier defaults from Vite maintained; no business logic yet.
+- Verify dev server runs locally (npm run dev) before ending stage if possible.
+
+### Stage B Completion
+- Manual Vite-style scaffolding created with React 18, React Router, Tailwind configs, and global layout.
+- Added placeholder pages for dashboard, interviews, questions, applicants, and take interview.
+- TODO: Install npm dependencies once registry access is available to run dev server.
+
+## Stage C Prompt
+- Implement `apiClient.js` with base URL + helpers, plus interview/question/applicant service modules with list fetchers.
+- Create shared hooks or utilities for loading/error handling as needed.
+- Build list pages consuming services with loading, empty, and error states (placeholder data until API integration validated).
+- Ensure no direct fetch calls in components; rely on services abstraction.
+
+### Stage C Completion
+- Implemented centralized API client with error handling and abort support plus resource-specific service modules.
+- Added `useAsyncData` hook for managing async lifecycle with cancellation.
+- Updated interview, question, and applicant pages to consume services with loading/error/empty states and refresh controls.
+- TODO: Enhance interview summaries with aggregated counts once related data fetching is implemented.
+
+## Stage D Prompt
+- Build shared forms for interviews, questions, and applicants supporting create/edit flows.
+- Wire CRUD actions via services, including optimistic refresh or state updates and validation messaging.
+- Introduce routing for add/edit pages and ensure no duplicate form logic across create/edit.
+- Maintain loading/error handling and confirm unique applicant link generation placeholder.
+
+### Stage D Completion
+- Created reusable Interview, Question, and Applicant form components with validation and accessibility labels.
+- Added editor pages leveraging shared forms for create/edit flows and wired CRUD actions via service layer.
+- Enhanced list pages with filtering, refresh controls, action buttons, and delete handling; applicant links generate/copy via tokens.
+- TODO: Improve question/applicant counts by aggregating related data from API in later stages.
+
+## Stage E Prompt
+- Build Take Interview flow: welcome screen, question progression (one per page) using recorded answers.
+- Implement recording widget with pause/resume, disable re-recording, convert audio to transcript via placeholder transcription service, then save text using answer API.
+- Ensure navigation is forward-only with persistent progress state and final thank-you screen.
+- Handle loading/error states when fetching questions/applicant context.
+
+### Stage E Completion
+- Implemented candidate take-interview flow with welcome, question progression, and thank-you views.
+- Added MediaRecorder-based audio controls (pause/resume, finish) with no re-recording and placeholder transcription workflow saving text answers via Answers API.
+- Hooked applicant lookup by token, question fetching, progress continuation, and applicant completion status updates with error handling.
+- TODO: Replace placeholder transcription utility with Whisper/Transformers integration and confirm API field mappings once schema is known.
+
+## Stage F Prompt
+- Design and integrate Advanced GenAI feature (e.g., HR summary) using placeholder that reads `VITE_LLM_API_KEY`.
+- Create UI entry point within dashboard or applicants page to trigger AI summary, displaying loading/error states and caching results.
+- Ensure API abstraction for LLM requests and document placeholder behavior for later key injection.
+
+### Stage F Completion
+- Added GenAI service placeholder that leverages `VITE_LLM_API_KEY` and simulates async summaries pending real API wiring.
+- Integrated AI summary panel on applicants page with loading/error handling and ability to refresh or close insights.
+- Wired applicant answers retrieval through service layer to feed the summary generator without direct fetch usage.
+- TODO: Replace simulated summary logic with actual LLM request once backend endpoint is available.
+
+## Stage G Prompt
+- Run lint/tests (if available) and document limitations (e.g., npm install restrictions).
+- Review implementation against QA checklist; ensure docs/README updated (including GenAI usage note).
+- Prepare final summary and screenshots if required; verify git status clean before delivery.
+
+### Stage G Completion
+- Attempted `npm install` but registry access returned HTTP 403; document limitation in README.
+- Reviewed implementation against QA checklist; docs already reference transcription options and GenAI placeholders.
+- Updated root README with setup instructions, environment variables, sample data guidance, and GenAI disclosure.
+- TODO: Integrate real transcription/LLM endpoints when credentials and network access become available.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# codex-test-intervierwapp
+# ReadySetHire – AI Interview Platform
+
+Front-end client for the ReadySetHire assessment. Built with React, React Router, and TailwindCSS. The app manages interviews, questions, applicants, and delivers a guided interview experience with audio recording and transcription placeholders.
+
+## Features
+- **Interview Management**: Create, edit, and delete interview templates with status badges and navigation into related resources.
+- **Question Bank**: Filterable list with shared create/edit form and difficulty tagging.
+- **Applicants**: Manage candidates, generate/copy unique interview links, and review AI-powered summaries.
+- **Take Interview Flow**: Candidate experience with welcome page, one-question-at-a-time navigation, MediaRecorder-based audio capture (pause/resume, no re-record), placeholder transcription, and thank-you screen.
+- **Advanced GenAI**: Simulated HR summary that reads `VITE_LLM_API_KEY` and can be replaced with a real LLM integration.
+
+## Getting Started
+1. Install dependencies (requires npm registry access):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+> **Note:** The provided execution environment blocks npm registry access. Run the install command locally where the registry is reachable.
+
+## Environment Variables
+Create a `.env.local` file with the following keys:
+
+```
+VITE_API_BASE_URL=https://comp2140a2.uqcloud.net/api
+VITE_LLM_API_KEY=YOUR-LLM-KEY-HERE
+```
+
+`VITE_LLM_API_KEY` is optional for the placeholder GenAI feature but required once a production integration is wired.
+
+## Documentation
+Additional docs live in the [`docs/`](./docs/README.md) folder:
+- Product requirements mapping
+- API usage notes
+- How to run instructions (including transcription options)
+- QA checklist used for self-review
+
+## Sample Data
+Use the interview creation form to add at least one interview (e.g., “Frontend Engineer Screen”) so rubric item 1.1 is satisfied. The UI supports seeding via the provided forms without additional tooling.
+
+## GenAI Disclosure
+This project currently ships with a simulated summary generator. Replace the implementation in `src/services/genAiApi.js` with your production GenAI call when you are ready to connect a commercial API.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation Index
+
+- [Product Requirements](./prd.md)
+- [API Reference](./api.md)
+- [How to Run](./how_to_run.md)
+- [QA Checklist](./qa_checklist.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,13 @@
+# API Reference
+
+- **Base URL**: `https://comp2140a2.uqcloud.net/api`
+- PostgREST-style filtering and CRUD endpoints.
+
+## Examples
+- `GET /interview` — list all interviews.
+- `GET /interview?id=eq.1` — fetch interview with `id = 1`.
+- `POST /interview` — create an interview (JSON body with required fields).
+- `PATCH /interview?id=eq.1` — update interview `1`.
+- `DELETE /interview?id=eq.1` — delete interview `1`.
+
+> Note: Table schemas beyond provided requirements must be discovered at runtime via `OPTIONS` or initial fetches; avoid hardcoding assumptions that are not confirmed by the API responses.

--- a/docs/how_to_run.md
+++ b/docs/how_to_run.md
@@ -1,0 +1,21 @@
+# How to Run
+
+## Prerequisites
+- Node.js 18+ and npm.
+
+## Setup
+```bash
+npm install
+npm run dev
+```
+
+## Environment Variables
+- `VITE_API_BASE_URL` — defaults to `https://comp2140a2.uqcloud.net/api` if unspecified.
+- `VITE_LLM_API_KEY` — provide the GenAI key when enabling advanced features (use `.env.local` during development).
+
+## Recording & Transcription
+- **Transformers.js**: Use the browser-based Whisper example from the course to transcribe recorded audio before sending to the Answers endpoint.
+- **Express + Whisper CLI**: Alternatively, proxy recordings to the sample Express service from the course that wraps the Whisper CLI; ensure the frontend only stores text transcripts.
+
+## Demo Data
+- Seed the UI with at least one example interview (e.g., "Frontend Engineer Screen") for rubric item 1.1.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,31 @@
+# Product Requirements
+
+## 2.1 Domain Model & Required Fields (Source: Project Brief)
+- **Interview**: Title, Job Role, Description, Status (Draft | Published).
+- **Question**: Question text, Difficulty (Easy | Intermediate | Advanced).
+- **Applicant**: Title, Firstname, Surname, Phone, Email, Interview Status (Not Started | Completed).
+
+## 2.2 Features & Interfaces (Source: Project Brief)
+1. **App Shell**: Consistent header, footer, and navigation. Provide guidance, icons/colors that support a clear flow.
+2. **Interviews**: List with counts for questions & applicants, CRUD actions, and navigation into questions/applicants.
+3. **Questions**: Scoped to an interview, support CRUD, text-only prompts.
+4. **Applicants**: List, create, and update applicants; generate & copy unique interview links; review questions and recorded answers.
+5. **Take Interview Experience**: Welcome view, one-question-per-page with forward-only navigation, recording controls (pause allowed, re-record forbidden), speech-to-text transcription saved to the Answer endpoint, thank-you completion view.
+6. **Advanced GenAI**: Provide an AI-powered enhancement (e.g., question generation, feedback, HR summary) leveraging supplied LLM key placeholder.
+
+## 2.3 Technology & Runtime (Source: Getting Started)
+- React + Vite + React Router frontend using centralized API services.
+- RESTful integration with `https://comp2140a2.uqcloud.net/api` using PostgREST conventions.
+- Shared forms for add/edit; no login or admin panel required.
+
+## 2.4 Rubric Highlights (Source: Rubric)
+- **1.1**: App runs with dependencies and ships with an example interview.
+- **1.2**: Interview CRUD with summaries and best practices.
+- **1.3**: Question CRUD per interview.
+- **1.5**: Applicant create/update plus unique interview link generation.
+- **1.6**: Recording and transcription saved as text responses.
+- **1.7**: One-page-per-question interview flow with forward-only progression.
+- **1.8**: View applicant status and associated Q&A.
+- **2.x**: CSS framework usage, consistent layout, clear guidance.
+- **3.x**: Code quality: functional patterns, reuse, centralized API, error handling, documentation.
+- **4.1**: Advanced GenAI feature delivering tangible value.

--- a/docs/qa_checklist.md
+++ b/docs/qa_checklist.md
@@ -1,0 +1,11 @@
+# QA Checklist
+
+- [ ] App installs and runs with sample interview data visible (Rubric 1.1).
+- [ ] Interviews list shows counts, supports CRUD, and navigates to related sections (Rubric 1.2).
+- [ ] Questions list scoped per interview with full CRUD and state handling (Rubric 1.3).
+- [ ] Applicants list allows create/update, generates unique interview links, and displays statuses/answers (Rubric 1.5 & 1.8).
+- [ ] Take Interview flow enforces one question per page, no backtracking, recording with pause-only controls, transcription stored as text (Rubric 1.6 & 1.7).
+- [ ] Centralized API services with error/loading/empty states (Rubric 3.3).
+- [ ] UI uses TailwindCSS with consistent header/footer/navigation and guidance cues (Rubric 2.x).
+- [ ] Advanced GenAI feature implemented using `VITE_LLM_API_KEY` (Rubric 4.1).
+- [ ] Documentation updated: README includes GenAI usage, `/docs` synced with implementation.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ReadySetHire</title>
+  </head>
+  <body class="bg-slate-50 text-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ready-set-hire",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.5",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,19 @@
+# Engineering Rules
+
+## Core Principles
+- **SOLID**: Design components and services that respect single responsibility, rely on abstractions, and can be extended without modification. Avoid tightly coupled modules that hinder testing.
+- **DRY**: Extract reusable logic into hooks, utilities, or shared components to prevent duplication. Review new code for repeated patterns.
+- **KISS**: Keep implementations straightforward; prefer simple data flows and obvious state transitions over clever but opaque solutions.
+- **Readability**: Name variables and functions descriptively, document non-obvious behavior, and maintain consistent formatting via ESLint/Prettier.
+
+## Anti-Patterns to Refactor
+- **Duplicated Fetch Logic** → Centralize API access in `/services` modules.
+- **God Components** → Split large UI components into smaller, focused units.
+- **Hidden Coupling** → Use props/state explicitly; avoid relying on shared mutable state.
+- **Incomplete Error Paths** → Surface loading, empty, and error states across the UI.
+
+## Self-Check Before Commit
+1. Are there repeated blocks that could live in hooks/components?
+2. Does each module have a single clear responsibility?
+3. Are error/loading states handled for every async operation?
+4. Are Type/prop assumptions documented or validated?

--- a/rules/deployment.md
+++ b/rules/deployment.md
@@ -1,0 +1,7 @@
+# Deployment Rules
+
+- No additional backend services may be introduced; the app must rely on the provided REST API.
+- Read API base URL from `VITE_API_BASE_URL`, defaulting to `https://comp2140a2.uqcloud.net/api` in development configs.
+- Any GenAI integrations must use `VITE_LLM_API_KEY`; never commit real secrets, only document how to supply them.
+- Ensure Vite build artifacts include source maps and reference assets relatively for static hosting.
+- Document environment configuration in `/docs/how_to_run.md` and the project `README.md`.

--- a/rules/frontend.md
+++ b/rules/frontend.md
@@ -1,0 +1,18 @@
+# Frontend Implementation Rules
+
+## Architecture
+- Maintain clear separation: `pages` orchestrate data, `components` render UI, `services` handle HTTP, `hooks` encapsulate logic, and `utils` host pure helpers.
+- Do **not** call `fetch` inside React components; always go through `/services/*Api.js` built atop `apiClient.js`.
+- Ensure every async view covers loading, empty, and error states.
+- Form screens must reuse shared create/edit forms to satisfy DRY and rubric expectations.
+- Keep routes and data flow unidirectional; validate URL params before use and guard against race conditions with cancellation or stale responses.
+
+## UI & Accessibility
+- Provide a consistent header, footer, and navigation bar across the app.
+- Include labels, helper text, and keyboard-accessible controls for all form inputs and recording features.
+- The Take Interview flow must present one question per screen with a single `Next` control, no backtracking, and prevent re-recording while allowing pause/resume.
+- After recording, transcribe audio to text and persist via the Answers API using text only.
+
+## Error Handling & Guidance
+- Surface actionable messages for network failures or validation issues.
+- Provide contextual guidance so users understand the process (interview creation, applicant management, recording steps).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,5 @@
+import AppRoutes from './routes/AppRoutes.jsx';
+
+export default function App() {
+  return <AppRoutes />;
+}

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -1,0 +1,54 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/interviews', label: 'Interviews' },
+  { to: '/questions', label: 'Questions' },
+  { to: '/applicants', label: 'Applicants' }
+];
+
+export default function AppLayout() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-indigo-600 text-white">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">ReadySetHire</h1>
+            <p className="text-sm text-indigo-100">
+              AI interview platform for collaborative hiring.
+            </p>
+          </div>
+          <nav className="flex flex-wrap gap-2">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                end={item.to === '/'}
+                className={({ isActive }) =>
+                  `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    isActive ? 'bg-white text-indigo-600' : 'bg-indigo-500 hover:bg-indigo-400'
+                  }`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <div className="max-w-6xl mx-auto px-4 py-8">
+          <Outlet />
+        </div>
+      </main>
+
+      <footer className="bg-slate-900 text-slate-100">
+        <div className="max-w-6xl mx-auto px-4 py-4 text-sm flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <span>&copy; {new Date().getFullYear()} ReadySetHire.</span>
+          <span>Empowering teams with AI-assisted interviews.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/ApplicantSummaryPanel.jsx
+++ b/src/components/ApplicantSummaryPanel.jsx
@@ -1,0 +1,45 @@
+export default function ApplicantSummaryPanel({ applicant, summary, loading, error, onClose, onGenerate }) {
+  if (!applicant) return null;
+
+  return (
+    <aside className="rounded-xl border border-indigo-100 bg-indigo-50 p-6 shadow-inner">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-indigo-700">
+            AI Insights for {applicant.firstname} {applicant.surname}
+          </h3>
+          <p className="text-sm text-indigo-600">
+            Summaries leverage your configured AI provider (placeholder until API key is supplied).
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onGenerate}
+            disabled={loading}
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? 'Generating...' : 'Refresh Summary'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center rounded-md border border-indigo-200 px-4 py-2 text-sm font-medium text-indigo-600 shadow-sm transition hover:border-indigo-300 hover:text-indigo-500"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg bg-white p-4 shadow-sm">
+        {error && <p className="text-sm text-rose-600">{error}</p>}
+        {!error && summary && (
+          <pre className="whitespace-pre-wrap text-sm text-slate-700">{summary}</pre>
+        )}
+        {!error && !summary && !loading && (
+          <p className="text-sm text-slate-600">Trigger the AI summary to review candidate highlights.</p>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/RecorderControls.jsx
+++ b/src/components/RecorderControls.jsx
@@ -1,0 +1,39 @@
+export default function RecorderControls({
+  isRecording,
+  isPaused,
+  hasRecording,
+  onStart,
+  onPause,
+  onResume,
+  onStop,
+  disabled
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        onClick={onStart}
+        disabled={isRecording || hasRecording || disabled}
+        className="inline-flex items-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        Start recording
+      </button>
+      <button
+        type="button"
+        onClick={isPaused ? onResume : onPause}
+        disabled={!isRecording || disabled}
+        className="inline-flex items-center rounded-md border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm transition hover:border-amber-300 hover:text-amber-600 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPaused ? 'Resume' : 'Pause'}
+      </button>
+      <button
+        type="button"
+        onClick={onStop}
+        disabled={!isRecording || disabled}
+        className="inline-flex items-center rounded-md border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-medium text-rose-600 shadow-sm transition hover:border-rose-300 hover:text-rose-500 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        Finish
+      </button>
+    </div>
+  );
+}

--- a/src/components/forms/ApplicantForm.jsx
+++ b/src/components/forms/ApplicantForm.jsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from 'react';
+
+const STATUS_OPTIONS = [
+  { label: 'Not Started', value: 'Not Started' },
+  { label: 'Completed', value: 'Completed' }
+];
+
+const defaultValues = {
+  title: '',
+  firstname: '',
+  surname: '',
+  phone: '',
+  email: '',
+  interview_id: '',
+  interview_status: 'Not Started'
+};
+
+export default function ApplicantForm({
+  initialValues,
+  interviewOptions,
+  onSubmit,
+  onCancel,
+  submitting,
+  errorMessage,
+  generatedLink,
+  onCopyLink
+}) {
+  const [values, setValues] = useState({ ...defaultValues, ...initialValues });
+  const [touched, setTouched] = useState({});
+
+  useEffect(() => {
+    setValues({ ...defaultValues, ...initialValues });
+  }, [initialValues]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleBlur = (event) => {
+    const { name } = event.target;
+    setTouched((prev) => ({ ...prev, [name]: true }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const requiredFields = ['firstname', 'surname', 'phone', 'email', 'interview_id'];
+    const missing = requiredFields.filter((field) => !values[field]?.toString().trim());
+    if (missing.length > 0) {
+      const newTouched = missing.reduce((acc, field) => ({ ...acc, [field]: true }), {});
+      setTouched((prev) => ({ ...prev, ...newTouched }));
+      return;
+    }
+    onSubmit({ ...values, interview_id: Number(values.interview_id) });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="title" className="block text-sm font-medium text-slate-700">
+            Title
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            value={values.title}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="interview_id" className="block text-sm font-medium text-slate-700">
+            Interview
+          </label>
+          <select
+            id="interview_id"
+            name="interview_id"
+            required
+            value={values.interview_id}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          >
+            <option value="" disabled>
+              Select interview
+            </option>
+            {interviewOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {touched.interview_id && !values.interview_id && (
+            <p className="text-sm text-rose-600">Interview selection is required.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="firstname" className="block text-sm font-medium text-slate-700">
+            First name
+          </label>
+          <input
+            id="firstname"
+            name="firstname"
+            type="text"
+            required
+            value={values.firstname}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.firstname && !values.firstname.trim() && (
+            <p className="text-sm text-rose-600">First name is required.</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="surname" className="block text-sm font-medium text-slate-700">
+            Surname
+          </label>
+          <input
+            id="surname"
+            name="surname"
+            type="text"
+            required
+            value={values.surname}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.surname && !values.surname.trim() && (
+            <p className="text-sm text-rose-600">Surname is required.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="phone" className="block text-sm font-medium text-slate-700">
+            Phone
+          </label>
+          <input
+            id="phone"
+            name="phone"
+            type="tel"
+            required
+            value={values.phone}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.phone && !values.phone.trim() && (
+            <p className="text-sm text-rose-600">Phone is required.</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="email" className="block text-sm font-medium text-slate-700">
+            Email
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            value={values.email}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.email && !values.email.trim() && (
+            <p className="text-sm text-rose-600">Email is required.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="interview_status" className="block text-sm font-medium text-slate-700">
+          Interview status
+        </label>
+        <select
+          id="interview_status"
+          name="interview_status"
+          value={values.interview_status}
+          onChange={handleChange}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {generatedLink && (
+        <div className="rounded-lg border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-700">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span className="font-medium">Interview link:</span>
+            <code className="break-all text-xs sm:text-sm">{generatedLink}</code>
+          </div>
+          {onCopyLink && (
+            <button
+              type="button"
+              onClick={onCopyLink}
+              className="mt-3 inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+            >
+              Copy link
+            </button>
+          )}
+        </div>
+      )}
+
+      {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex items-center justify-center rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-500"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Saving...' : 'Save Applicant'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/forms/InterviewForm.jsx
+++ b/src/components/forms/InterviewForm.jsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+
+const STATUS_OPTIONS = [
+  { label: 'Draft', value: 'Draft' },
+  { label: 'Published', value: 'Published' }
+];
+
+const defaultValues = {
+  title: '',
+  job_role: '',
+  description: '',
+  status: 'Draft'
+};
+
+export default function InterviewForm({ initialValues, onSubmit, onCancel, submitting, errorMessage }) {
+  const [values, setValues] = useState({ ...defaultValues, ...initialValues });
+  const [touched, setTouched] = useState({});
+
+  useEffect(() => {
+    setValues({ ...defaultValues, ...initialValues });
+  }, [initialValues]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleBlur = (event) => {
+    const { name } = event.target;
+    setTouched((prev) => ({ ...prev, [name]: true }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!values.title.trim() || !values.job_role.trim() || !values.description.trim()) {
+      setTouched({ title: true, job_role: true, description: true });
+      return;
+    }
+    onSubmit(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="title" className="block text-sm font-medium text-slate-700">
+            Title
+          </label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            required
+            value={values.title}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.title && !values.title.trim() && (
+            <p className="text-sm text-rose-600">Title is required.</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="job_role" className="block text-sm font-medium text-slate-700">
+            Job Role
+          </label>
+          <input
+            id="job_role"
+            name="job_role"
+            type="text"
+            required
+            value={values.job_role}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+          {touched.job_role && !values.job_role.trim() && (
+            <p className="text-sm text-rose-600">Job role is required.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="description" className="block text-sm font-medium text-slate-700">
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          required
+          rows={4}
+          value={values.description}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        />
+        {touched.description && !values.description.trim() && (
+          <p className="text-sm text-rose-600">Description is required.</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="status" className="block text-sm font-medium text-slate-700">
+          Status
+        </label>
+        <select
+          id="status"
+          name="status"
+          value={values.status}
+          onChange={handleChange}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex items-center justify-center rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-500"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Saving...' : 'Save Interview'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/forms/QuestionForm.jsx
+++ b/src/components/forms/QuestionForm.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+
+const DIFFICULTY_OPTIONS = [
+  { label: 'Easy', value: 'Easy' },
+  { label: 'Intermediate', value: 'Intermediate' },
+  { label: 'Advanced', value: 'Advanced' }
+];
+
+const defaultValues = {
+  question: '',
+  difficulty: 'Easy',
+  interview_id: ''
+};
+
+export default function QuestionForm({
+  initialValues,
+  interviewOptions,
+  onSubmit,
+  onCancel,
+  submitting,
+  errorMessage
+}) {
+  const [values, setValues] = useState({ ...defaultValues, ...initialValues });
+  const [touched, setTouched] = useState({});
+
+  useEffect(() => {
+    setValues({ ...defaultValues, ...initialValues });
+  }, [initialValues]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleBlur = (event) => {
+    const { name } = event.target;
+    setTouched((prev) => ({ ...prev, [name]: true }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!values.question.trim() || !values.interview_id) {
+      setTouched({ question: true, interview_id: true });
+      return;
+    }
+    onSubmit({ ...values, interview_id: Number(values.interview_id) });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div className="space-y-2">
+        <label htmlFor="interview_id" className="block text-sm font-medium text-slate-700">
+          Interview
+        </label>
+        <select
+          id="interview_id"
+          name="interview_id"
+          required
+          value={values.interview_id}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          <option value="" disabled>
+            Select interview
+          </option>
+          {interviewOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {touched.interview_id && !values.interview_id && (
+          <p className="text-sm text-rose-600">An interview is required.</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="question" className="block text-sm font-medium text-slate-700">
+          Question
+        </label>
+        <textarea
+          id="question"
+          name="question"
+          rows={4}
+          required
+          value={values.question}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        />
+        {touched.question && !values.question.trim() && (
+          <p className="text-sm text-rose-600">Question text is required.</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="difficulty" className="block text-sm font-medium text-slate-700">
+          Difficulty
+        </label>
+        <select
+          id="difficulty"
+          name="difficulty"
+          value={values.difficulty}
+          onChange={handleChange}
+          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          {DIFFICULTY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
+
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex items-center justify-center rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-500"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Saving...' : 'Save Question'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/hooks/useAsyncData.js
+++ b/src/hooks/useAsyncData.js
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ApiError } from '../services/apiClient.js';
+
+export function useAsyncData(asyncFn, dependencies = []) {
+  const abortRef = useRef();
+  const [state, setState] = useState({ data: null, loading: true, error: null });
+
+  const execute = useCallback(async () => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const result = await asyncFn({ signal: controller.signal });
+      setState({ data: result, loading: false, error: null });
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      if (error instanceof ApiError) {
+        setState({ data: null, loading: false, error });
+      } else {
+        setState({ data: null, loading: false, error: new Error(error.message || 'Unexpected error') });
+      }
+    }
+  }, dependencies); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    execute();
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [execute]);
+
+  return {
+    ...state,
+    refetch: execute
+  };
+}

--- a/src/hooks/useAudioRecorder.js
+++ b/src/hooks/useAudioRecorder.js
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useAudioRecorder() {
+  const mediaRecorderRef = useRef(null);
+  const chunksRef = useRef([]);
+  const streamRef = useRef(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [hasRecording, setHasRecording] = useState(false);
+  const [error, setError] = useState('');
+  const [audioBlob, setAudioBlob] = useState(null);
+  const [audioUrl, setAudioUrl] = useState('');
+
+  const cleanup = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+    }
+    streamRef.current = null;
+    mediaRecorderRef.current = null;
+  }, []);
+
+  useEffect(() => () => reset(), [reset]);
+
+  const reset = useCallback(() => {
+    chunksRef.current = [];
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+    }
+    setAudioBlob(null);
+    setAudioUrl('');
+    setHasRecording(false);
+    setIsRecording(false);
+    setIsPaused(false);
+    setError('');
+    cleanup();
+  }, [audioUrl, cleanup]);
+
+  const ensureRecorder = useCallback(async () => {
+    if (mediaRecorderRef.current) return mediaRecorderRef.current;
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error('Audio recording is not supported in this browser.');
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    streamRef.current = stream;
+    const recorder = new MediaRecorder(stream);
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        chunksRef.current.push(event.data);
+      }
+    };
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+      setAudioBlob(blob);
+      const objectUrl = URL.createObjectURL(blob);
+      setAudioUrl(objectUrl);
+      setHasRecording(true);
+      setIsRecording(false);
+      setIsPaused(false);
+      cleanup();
+    };
+    recorder.onerror = (event) => {
+      setError(event.error?.message || 'Recording failed');
+      cleanup();
+    };
+    mediaRecorderRef.current = recorder;
+    return recorder;
+  }, [cleanup]);
+
+  const start = useCallback(async () => {
+    try {
+      const recorder = await ensureRecorder();
+      chunksRef.current = [];
+      recorder.start();
+      setIsRecording(true);
+      setIsPaused(false);
+      setHasRecording(false);
+      setAudioBlob(null);
+      setAudioUrl('');
+    } catch (startError) {
+      setError(startError.message);
+    }
+  }, [ensureRecorder]);
+
+  const pause = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state !== 'recording') return;
+    recorder.pause();
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state !== 'paused') return;
+    recorder.resume();
+    setIsPaused(false);
+  }, []);
+
+  const stop = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state === 'inactive') return;
+    recorder.stop();
+  }, []);
+
+  return {
+    start,
+    pause,
+    resume,
+    stop,
+    reset,
+    isRecording,
+    isPaused,
+    hasRecording,
+    audioBlob,
+    audioUrl,
+    error
+  };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom';
+
+const quickLinks = [
+  {
+    title: 'Plan Interviews',
+    description: 'Create templates, assign AI-generated questions, and publish to candidates.',
+    to: '/interviews'
+  },
+  {
+    title: 'Curate Questions',
+    description: 'Review the question bank and tailor difficulty for each role.',
+    to: '/questions'
+  },
+  {
+    title: 'Manage Applicants',
+    description: 'Invite candidates and monitor completion with AI-assisted summaries.',
+    to: '/applicants'
+  }
+];
+
+export default function Dashboard() {
+  return (
+    <section className="space-y-10">
+      <header className="space-y-3">
+        <h2 className="text-3xl font-semibold text-slate-900">Welcome back!</h2>
+        <p className="text-slate-600 max-w-2xl">
+          Configure interviews, collaborate with your team, and leverage AI-powered assistance to streamline hiring decisions.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {quickLinks.map((link) => (
+          <Link
+            key={link.to}
+            to={link.to}
+            className="group rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <h3 className="text-xl font-semibold text-indigo-600 group-hover:text-indigo-500">{link.title}</h3>
+            <p className="mt-2 text-sm text-slate-600">{link.description}</p>
+            <span className="mt-4 inline-flex items-center text-sm font-medium text-indigo-500 group-hover:text-indigo-400">
+              Go to {link.title}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export default function NotFound() {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-3xl font-semibold text-slate-900">Page not found</h2>
+      <p className="text-slate-600">The page you were looking for does not exist.</p>
+      <Link to="/" className="inline-flex items-center text-indigo-600 hover:text-indigo-500">
+        Return to dashboard
+      </Link>
+    </section>
+  );
+}

--- a/src/pages/applicants/ApplicantEditorPage.jsx
+++ b/src/pages/applicants/ApplicantEditorPage.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ApplicantForm from '../../components/forms/ApplicantForm.jsx';
+import { listInterviews } from '../../services/interviewApi.js';
+import { createApplicant, getApplicant, updateApplicant } from '../../services/applicantApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+import { buildApplicantLink, generateApplicantToken } from '../../utils/interviewLinks.js';
+
+export default function ApplicantEditorPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditing = Boolean(id);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [linkToken, setLinkToken] = useState('');
+
+  const interviewsResult = useAsyncData(({ signal }) => listInterviews({ signal }), []);
+  const applicantResult = useAsyncData(
+    ({ signal }) => (isEditing ? getApplicant(id, { signal }) : Promise.resolve(null)),
+    [id]
+  );
+
+  useEffect(() => {
+    const record = Array.isArray(applicantResult.data) ? applicantResult.data[0] : applicantResult.data;
+    if (!record) return;
+    const tokenCandidate = record?.invite_token || record?.token || record?.link_token || record?.access_token;
+    if (tokenCandidate) {
+      setLinkToken(tokenCandidate);
+    }
+  }, [applicantResult.data]);
+
+  useEffect(() => {
+    if (!isEditing && !linkToken) {
+      setLinkToken(generateApplicantToken());
+    }
+  }, [isEditing, linkToken]);
+
+  const interviewOptions = useMemo(
+    () =>
+      (interviewsResult.data ?? []).map((interview) => ({
+        value: interview.id,
+        label: `${interview.title} (${interview.job_role ?? 'Role'})`
+      })),
+    [interviewsResult.data]
+  );
+
+  const applicant = useMemo(
+    () => (Array.isArray(applicantResult.data) ? applicantResult.data[0] : applicantResult.data),
+    [applicantResult.data]
+  );
+
+  const ensureToken = () => {
+    if (!linkToken) {
+      const token = generateApplicantToken();
+      setLinkToken(token);
+      return token;
+    }
+    return linkToken;
+  };
+
+  const handleSubmit = async (values) => {
+    setSubmitting(true);
+    setErrorMessage('');
+    const token = ensureToken();
+    const payload = { ...values, invite_token: token };
+    try {
+      if (isEditing) {
+        await updateApplicant(id, payload);
+      } else {
+        await createApplicant(payload);
+      }
+      navigate('/applicants');
+    } catch (submissionError) {
+      setErrorMessage(submissionError.message || 'Unable to save applicant.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => navigate('/applicants');
+
+  const handleCopyLink = async () => {
+    const token = ensureToken();
+    const link = buildApplicantLink(token);
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(link);
+        setErrorMessage('');
+      }
+    } catch (copyError) {
+      setErrorMessage('Unable to copy link automatically. Copy it manually.');
+    }
+  };
+
+  const generatedLink = linkToken ? buildApplicantLink(linkToken) : '';
+
+  if (interviewsResult.loading || applicantResult.loading) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Applicant' : 'Create Applicant'}</h2>
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading...</div>
+      </section>
+    );
+  }
+
+  if (interviewsResult.error) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Applicant' : 'Create Applicant'}</h2>
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load interviews. {interviewsResult.error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (applicantResult.error) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Applicant' : 'Create Applicant'}</h2>
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load applicant. {applicantResult.error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (isEditing && !applicant) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">Applicant not found</h2>
+        <p className="text-slate-600">The requested applicant could not be located.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Applicant' : 'Create Applicant'}</h2>
+        <p className="text-slate-600">
+          {isEditing ? 'Update applicant contact details and status.' : 'Invite a candidate and share the interview link.'}
+        </p>
+      </header>
+
+      <ApplicantForm
+        initialValues={applicant}
+        interviewOptions={interviewOptions}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        submitting={submitting}
+        errorMessage={errorMessage}
+        generatedLink={generatedLink}
+        onCopyLink={generatedLink ? handleCopyLink : undefined}
+      />
+    </section>
+  );
+}

--- a/src/pages/applicants/ApplicantsPage.jsx
+++ b/src/pages/applicants/ApplicantsPage.jsx
@@ -1,0 +1,214 @@
+import { Link, useSearchParams } from 'react-router-dom';
+import { useCallback, useMemo, useState } from 'react';
+import { listApplicants } from '../../services/applicantApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+import { buildApplicantLink } from '../../utils/interviewLinks.js';
+import { listAnswers } from '../../services/answerApi.js';
+import { generateApplicantSummary } from '../../services/genAiApi.js';
+import ApplicantSummaryPanel from '../../components/ApplicantSummaryPanel.jsx';
+
+const statusStyles = {
+  'Not Started': 'bg-slate-200 text-slate-700',
+  Completed: 'bg-emerald-100 text-emerald-700'
+};
+
+export default function ApplicantsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const interviewId = searchParams.get('interview') || undefined;
+  const { data, loading, error, refetch } = useAsyncData(
+    ({ signal }) => listApplicants(interviewId, { signal }),
+    [interviewId]
+  );
+  const applicants = useMemo(() => data ?? [], [data]);
+  const [copyMessage, setCopyMessage] = useState('');
+  const [summaryApplicant, setSummaryApplicant] = useState(null);
+  const [summaryText, setSummaryText] = useState('');
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [summaryError, setSummaryError] = useState('');
+
+  const handleCopyLink = async (token) => {
+    const link = buildApplicantLink(token);
+    try {
+      if (navigator.clipboard?.writeText && link) {
+        await navigator.clipboard.writeText(link);
+        setCopyMessage('Link copied to clipboard.');
+        setTimeout(() => setCopyMessage(''), 2000);
+      }
+    } catch (copyError) {
+      setCopyMessage('Unable to copy link automatically.');
+    }
+  };
+
+  const clearFilter = () => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('interview');
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const runSummary = useCallback(
+    async (applicantToSummarize) => {
+      if (!applicantToSummarize) return;
+      setSummaryApplicant(applicantToSummarize);
+      setSummaryLoading(true);
+      setSummaryError('');
+      setSummaryText('');
+      try {
+        const answersResponse = await listAnswers(applicantToSummarize.id).catch(() => []);
+        const summary = await generateApplicantSummary({ applicant: applicantToSummarize, answers: answersResponse });
+        setSummaryText(summary);
+      } catch (summaryErr) {
+        setSummaryError(summaryErr.message || 'Unable to generate AI summary.');
+      } finally {
+        setSummaryLoading(false);
+      }
+    },
+    []
+  );
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-3xl font-semibold text-slate-900">Applicants</h2>
+          <p className="text-slate-600">Track candidate invitations and completion status.</p>
+          {interviewId && (
+            <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+              Filtering by interview #{interviewId}
+              <button type="button" onClick={clearFilter} className="text-indigo-500 underline-offset-2 hover:underline">
+                Clear
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={refetch}
+            className="inline-flex items-center rounded-md border border-indigo-200 bg-white px-4 py-2 text-sm font-medium text-indigo-600 shadow-sm transition hover:border-indigo-300 hover:text-indigo-500"
+          >
+            Refresh
+          </button>
+          <Link
+            to="/applicants/new"
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+          >
+            New Applicant
+          </Link>
+        </div>
+      </header>
+
+      {copyMessage && <p className="text-sm text-indigo-600">{copyMessage}</p>}
+
+      {loading && (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
+          Loading applicants...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load applicants. {error.message}
+        </div>
+      )}
+
+      {!loading && !error && applicants.length === 0 && (
+        <div className="rounded-lg border border-dashed border-slate-300 p-8 text-center text-slate-500">
+          Invite candidates to interviews to populate this list.
+        </div>
+      )}
+
+      {!loading && !error && applicants.length > 0 && (
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Applicant
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Contact
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Interview
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {applicants.map((applicant) => {
+                const token = applicant.invite_token || applicant.token || applicant.link_token || applicant.access_token;
+                const link = token ? buildApplicantLink(token) : '';
+                return (
+                  <tr key={applicant.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 text-sm font-medium text-slate-900">
+                      {applicant.title ? `${applicant.title} ` : ''}
+                      {applicant.firstname} {applicant.surname}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-slate-600">
+                      <div>{applicant.email}</div>
+                      <div className="text-xs text-slate-500">{applicant.phone}</div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-slate-600">{applicant.interview_id ?? '—'}</td>
+                    <td className="px-4 py-3 text-sm">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                          statusStyles[applicant.interview_status] ?? 'bg-slate-100 text-slate-600'
+                        }`}
+                      >
+                        {applicant.interview_status ?? 'Not Started'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right text-sm">
+                      <div className="flex flex-wrap justify-end gap-2">
+                        {link && (
+                          <button
+                            type="button"
+                            onClick={() => handleCopyLink(token)}
+                            className="rounded-md border border-indigo-200 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:border-indigo-300 hover:text-indigo-500"
+                          >
+                            Copy link
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => runSummary(applicant)}
+                          className="rounded-md border border-indigo-200 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:border-indigo-300 hover:text-indigo-500"
+                        >
+                          AI Summary
+                        </button>
+                        <Link
+                          to={`/applicants/${applicant.id}/edit`}
+                          className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-500"
+                        >
+                          Edit
+                        </Link>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ApplicantSummaryPanel
+        applicant={summaryApplicant}
+        summary={summaryText}
+        loading={summaryLoading}
+        error={summaryError}
+        onClose={() => {
+          setSummaryApplicant(null);
+          setSummaryText('');
+          setSummaryError('');
+        }}
+        onGenerate={() => runSummary(summaryApplicant)}
+      />
+    </section>
+  );
+}

--- a/src/pages/interviews/InterviewEditorPage.jsx
+++ b/src/pages/interviews/InterviewEditorPage.jsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import InterviewForm from '../../components/forms/InterviewForm.jsx';
+import { createInterview, getInterview, updateInterview } from '../../services/interviewApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+
+export default function InterviewEditorPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditing = Boolean(id);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const { data, loading, error } = useAsyncData(
+    ({ signal }) => (isEditing ? getInterview(id, { signal }) : Promise.resolve(null)),
+    [id]
+  );
+
+  const interview = useMemo(() => (Array.isArray(data) ? data[0] : data), [data]);
+
+  const handleSubmit = async (values) => {
+    setSubmitting(true);
+    setErrorMessage('');
+    try {
+      if (isEditing) {
+        await updateInterview(id, values);
+      } else {
+        await createInterview(values);
+      }
+      navigate('/interviews');
+    } catch (submissionError) {
+      setErrorMessage(submissionError.message || 'Unable to save interview.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => navigate('/interviews');
+
+  if (loading) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Interview' : 'Create Interview'}</h2>
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading...</div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Interview' : 'Create Interview'}</h2>
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load interview. {error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (isEditing && !interview) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">Interview not found</h2>
+        <p className="text-slate-600">The requested interview could not be located.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Interview' : 'Create Interview'}</h2>
+        <p className="text-slate-600">
+          {isEditing ? 'Update interview details and status.' : 'Define a new interview template for your team.'}
+        </p>
+      </header>
+
+      <InterviewForm
+        initialValues={interview}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        submitting={submitting}
+        errorMessage={errorMessage}
+      />
+    </section>
+  );
+}

--- a/src/pages/interviews/InterviewsPage.jsx
+++ b/src/pages/interviews/InterviewsPage.jsx
@@ -1,0 +1,155 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { listInterviews, deleteInterview } from '../../services/interviewApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+
+export default function InterviewsPage() {
+  const navigate = useNavigate();
+  const [actionError, setActionError] = useState('');
+  const { data, loading, error, refetch } = useAsyncData(({ signal }) => listInterviews({ signal }), []);
+
+  const interviews = useMemo(() => data ?? [], [data]);
+
+  const handleDelete = async (id) => {
+    const confirmed = window.confirm('Delete this interview? This cannot be undone.');
+    if (!confirmed) return;
+    setActionError('');
+    try {
+      await deleteInterview(id);
+      refetch();
+    } catch (deleteError) {
+      setActionError(deleteError.message || 'Unable to delete interview.');
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-3xl font-semibold text-slate-900">Interviews</h2>
+          <p className="text-slate-600">
+            Review interview templates, track question coverage, and monitor applicant progress.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={refetch}
+            className="inline-flex items-center rounded-md border border-indigo-200 bg-white px-4 py-2 text-sm font-medium text-indigo-600 shadow-sm transition hover:border-indigo-300 hover:text-indigo-500"
+          >
+            Refresh
+          </button>
+          <Link
+            to="/interviews/new"
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+          >
+            New Interview
+          </Link>
+        </div>
+      </header>
+
+      {actionError && <p className="text-sm text-rose-600">{actionError}</p>}
+
+      {loading && (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
+          Loading interviews...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load interviews. {error.message}
+        </div>
+      )}
+
+      {!loading && !error && interviews.length === 0 && (
+        <div className="rounded-lg border border-dashed border-slate-300 p-8 text-center text-slate-500">
+          No interviews available yet. Create one to get started.
+        </div>
+      )}
+
+      {!loading && !error && interviews.length > 0 && (
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Title
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Role
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Questions
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Applicants
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {interviews.map((interview) => (
+                <tr key={interview.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 text-sm font-medium text-slate-900">{interview.title}</td>
+                  <td className="px-4 py-3 text-sm text-slate-600">{interview.job_role ?? '—'}</td>
+                  <td className="px-4 py-3 text-sm">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                        interview.status === 'Published'
+                          ? 'bg-emerald-100 text-emerald-700'
+                          : 'bg-amber-100 text-amber-700'
+                      }`}
+                    >
+                      {interview.status ?? 'Draft'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-indigo-600">
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/questions?interview=${interview.id}`)}
+                      className="underline-offset-2 hover:underline"
+                    >
+                      {interview.questions_count ?? interview.questions?.length ?? '—'}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-indigo-600">
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/applicants?interview=${interview.id}`)}
+                      className="underline-offset-2 hover:underline"
+                    >
+                      {interview.applicants_count ?? interview.applicants?.length ?? '—'}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-right text-sm">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        to={`/interviews/${interview.id}/edit`}
+                        className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-500"
+                      >
+                        Edit
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(interview.id)}
+                        className="rounded-md border border-rose-200 px-3 py-1.5 text-xs font-medium text-rose-600 hover:border-rose-300 hover:text-rose-500"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/questions/QuestionEditorPage.jsx
+++ b/src/pages/questions/QuestionEditorPage.jsx
@@ -1,0 +1,112 @@
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import QuestionForm from '../../components/forms/QuestionForm.jsx';
+import { listInterviews } from '../../services/interviewApi.js';
+import { createQuestion, getQuestion, updateQuestion } from '../../services/questionApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+
+export default function QuestionEditorPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditing = Boolean(id);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const interviewsResult = useAsyncData(({ signal }) => listInterviews({ signal }), []);
+  const questionResult = useAsyncData(
+    ({ signal }) => (isEditing ? getQuestion(id, { signal }) : Promise.resolve(null)),
+    [id]
+  );
+
+  const interviewOptions = useMemo(
+    () =>
+      (interviewsResult.data ?? []).map((interview) => ({
+        value: interview.id,
+        label: `${interview.title} (${interview.job_role ?? 'Role'})`
+      })),
+    [interviewsResult.data]
+  );
+
+  const question = useMemo(() => (Array.isArray(questionResult.data) ? questionResult.data[0] : questionResult.data), [
+    questionResult.data
+  ]);
+
+  const handleSubmit = async (values) => {
+    setSubmitting(true);
+    setErrorMessage('');
+    try {
+      if (isEditing) {
+        await updateQuestion(id, values);
+      } else {
+        await createQuestion(values);
+      }
+      navigate('/questions');
+    } catch (submissionError) {
+      setErrorMessage(submissionError.message || 'Unable to save question.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => navigate('/questions');
+
+  if (interviewsResult.loading || questionResult.loading) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Question' : 'Create Question'}</h2>
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">Loading...</div>
+      </section>
+    );
+  }
+
+  if (interviewsResult.error) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Question' : 'Create Question'}</h2>
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load interviews. {interviewsResult.error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (questionResult.error) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Question' : 'Create Question'}</h2>
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load question. {questionResult.error.message}
+        </div>
+      </section>
+    );
+  }
+
+  if (isEditing && !question) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-3xl font-semibold text-slate-900">Question not found</h2>
+        <p className="text-slate-600">The requested question could not be located.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h2 className="text-3xl font-semibold text-slate-900">{isEditing ? 'Edit Question' : 'Create Question'}</h2>
+        <p className="text-slate-600">
+          {isEditing ? 'Update the question prompt and difficulty.' : 'Add a new question to your interview bank.'}
+        </p>
+      </header>
+
+      <QuestionForm
+        initialValues={question}
+        interviewOptions={interviewOptions}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        submitting={submitting}
+        errorMessage={errorMessage}
+      />
+    </section>
+  );
+}

--- a/src/pages/questions/QuestionsPage.jsx
+++ b/src/pages/questions/QuestionsPage.jsx
@@ -1,0 +1,135 @@
+import { Link, useSearchParams } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { listQuestions, deleteQuestion } from '../../services/questionApi.js';
+import { useAsyncData } from '../../hooks/useAsyncData.js';
+
+const difficultyStyles = {
+  Easy: 'bg-emerald-100 text-emerald-700',
+  Intermediate: 'bg-amber-100 text-amber-700',
+  Advanced: 'bg-rose-100 text-rose-700'
+};
+
+export default function QuestionsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [actionError, setActionError] = useState('');
+  const interviewId = searchParams.get('interview') || undefined;
+
+  const { data, loading, error, refetch } = useAsyncData(
+    ({ signal }) => listQuestions(interviewId, { signal }),
+    [interviewId]
+  );
+
+  const questions = useMemo(() => data ?? [], [data]);
+
+  const clearFilter = () => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('interview');
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const handleDelete = async (id) => {
+    const confirmed = window.confirm('Delete this question?');
+    if (!confirmed) return;
+    setActionError('');
+    try {
+      await deleteQuestion(id);
+      refetch();
+    } catch (deleteError) {
+      setActionError(deleteError.message || 'Unable to delete question.');
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-3xl font-semibold text-slate-900">Question Bank</h2>
+          <p className="text-slate-600">Review, categorize, and refine your interview questions.</p>
+          {interviewId && (
+            <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
+              Filtering by interview #{interviewId}
+              <button type="button" onClick={clearFilter} className="text-indigo-500 underline-offset-2 hover:underline">
+                Clear
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={refetch}
+            className="inline-flex items-center rounded-md border border-indigo-200 bg-white px-4 py-2 text-sm font-medium text-indigo-600 shadow-sm transition hover:border-indigo-300 hover:text-indigo-500"
+          >
+            Refresh
+          </button>
+          <Link
+            to="/questions/new"
+            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+          >
+            New Question
+          </Link>
+        </div>
+      </header>
+
+      {actionError && <p className="text-sm text-rose-600">{actionError}</p>}
+
+      {loading && (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
+          Loading questions...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm">
+          Unable to load questions. {error.message}
+        </div>
+      )}
+
+      {!loading && !error && questions.length === 0 && (
+        <div className="rounded-lg border border-dashed border-slate-300 p-8 text-center text-slate-500">
+          No questions yet. Generate or add questions to enrich your interviews.
+        </div>
+      )}
+
+      {!loading && !error && questions.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {questions.map((question) => (
+            <article key={question.id} className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <h3 className="text-lg font-semibold text-slate-900">{question.question}</h3>
+                  {question.interview_id && (
+                    <p className="text-xs uppercase tracking-wide text-slate-500">Interview #{question.interview_id}</p>
+                  )}
+                </div>
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                    difficultyStyles[question.difficulty] ?? 'bg-slate-100 text-slate-600'
+                  }`}
+                >
+                  {question.difficulty ?? 'Unrated'}
+                </span>
+              </div>
+              {question.description && <p className="mt-3 text-sm text-slate-600">{question.description}</p>}
+              <div className="mt-4 flex items-center justify-end gap-2">
+                <Link
+                  to={`/questions/${question.id}/edit`}
+                  className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-500"
+                >
+                  Edit
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(question.id)}
+                  className="rounded-md border border-rose-200 px-3 py-1.5 text-xs font-medium text-rose-600 hover:border-rose-300 hover:text-rose-500"
+                >
+                  Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/take-interview/TakeInterviewLanding.jsx
+++ b/src/pages/take-interview/TakeInterviewLanding.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import RecorderControls from '../../components/RecorderControls.jsx';
+import { useAudioRecorder } from '../../hooks/useAudioRecorder.js';
+import { listQuestions } from '../../services/questionApi.js';
+import { findApplicantByToken, updateApplicant } from '../../services/applicantApi.js';
+import { createAnswer, listAnswers } from '../../services/answerApi.js';
+import { transcribeAudio } from '../../utils/transcription.js';
+
+const STEP = {
+  LOADING: 'loading',
+  ERROR: 'error',
+  WELCOME: 'welcome',
+  QUESTION: 'question',
+  COMPLETE: 'complete'
+};
+
+export default function TakeInterviewLanding() {
+  const { token } = useParams();
+  const [step, setStep] = useState(STEP.LOADING);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [applicant, setApplicant] = useState(null);
+  const [questions, setQuestions] = useState([]);
+  const [answers, setAnswers] = useState({});
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [transcriptionMessage, setTranscriptionMessage] = useState('');
+
+  const recorder = useAudioRecorder();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      try {
+        setStep(STEP.LOADING);
+        const applicantResponse = await findApplicantByToken(token, { signal: controller.signal });
+        const applicantRecord = Array.isArray(applicantResponse) ? applicantResponse[0] : applicantResponse;
+        if (!applicantRecord) {
+          setErrorMessage('We could not find your interview invitation.');
+          setStep(STEP.ERROR);
+          return;
+        }
+        setApplicant(applicantRecord);
+        const [questionsResponse, answersResponse] = await Promise.all([
+          listQuestions(applicantRecord.interview_id, { signal: controller.signal }),
+          listAnswers(applicantRecord.id, { signal: controller.signal }).catch(() => [])
+        ]);
+        const normalizedQuestions = Array.isArray(questionsResponse) ? questionsResponse : [];
+        setQuestions(normalizedQuestions);
+
+        let answerMap = {};
+        if (Array.isArray(answersResponse)) {
+          answerMap = answersResponse.reduce((acc, answer) => {
+            if (answer.question_id) {
+              acc[answer.question_id] = answer.transcript ?? answer.answer_text ?? answer.response ?? '';
+            }
+            return acc;
+          }, {});
+          setAnswers(answerMap);
+        }
+
+        if (normalizedQuestions.length === 0) {
+          setErrorMessage('No questions were assigned to this interview.');
+          setStep(STEP.ERROR);
+          return;
+        }
+
+        const firstUnansweredIndex = normalizedQuestions.findIndex((question) => !answerMap[question.id]);
+        if (firstUnansweredIndex === -1) {
+          setCurrentIndex(0);
+          setStep(STEP.COMPLETE);
+        } else {
+          setCurrentIndex(firstUnansweredIndex);
+          setStep(STEP.WELCOME);
+        }
+      } catch (loadError) {
+        if (loadError.name === 'AbortError') return;
+        setErrorMessage(loadError.message || 'Unable to load interview details.');
+        setStep(STEP.ERROR);
+      }
+    }
+    load();
+    return () => controller.abort();
+  }, [token]);
+
+  const currentQuestion = useMemo(() => questions[currentIndex], [questions, currentIndex]);
+  const totalQuestions = questions.length;
+
+  const startInterview = () => {
+    if (!questions.length) {
+      setErrorMessage('No questions were assigned to this interview.');
+      setStep(STEP.ERROR);
+      return;
+    }
+    setStep(STEP.QUESTION);
+  };
+
+  const handleSubmitAnswer = async () => {
+    if (!currentQuestion) return;
+    if (!recorder.audioBlob) {
+      setErrorMessage('Please record your answer before continuing.');
+      return;
+    }
+    setSaving(true);
+    setTranscriptionMessage('Transcribing your answer, please wait...');
+    setErrorMessage('');
+    try {
+      const transcript = await transcribeAudio(recorder.audioBlob);
+      const payload = {
+        applicant_id: applicant.id,
+        question_id: currentQuestion.id,
+        transcript
+      };
+      await createAnswer(payload);
+      setAnswers((prev) => ({ ...prev, [currentQuestion.id]: transcript }));
+      recorder.reset();
+      setTranscriptionMessage('Answer saved successfully.');
+      const nextIndex = currentIndex + 1;
+      if (nextIndex < questions.length) {
+        setCurrentIndex(nextIndex);
+        setTimeout(() => setTranscriptionMessage(''), 1500);
+      } else {
+        await updateApplicant(applicant.id, { interview_status: 'Completed' });
+        setApplicant((prev) => (prev ? { ...prev, interview_status: 'Completed' } : prev));
+        setStep(STEP.COMPLETE);
+      }
+    } catch (submitError) {
+      setErrorMessage(submitError.message || 'Unable to save your answer.');
+      setTranscriptionMessage('');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderWelcome = () => (
+    <section className="space-y-6">
+      <header className="space-y-3">
+        <p className="text-sm uppercase tracking-wide text-indigo-500">Welcome</p>
+        <h2 className="text-3xl font-semibold text-slate-900">Hi {applicant?.firstname}!</h2>
+        <p className="text-slate-600 max-w-2xl">
+          You are about to begin the {applicant?.job_role || 'interview'} experience. Please ensure you are in a quiet
+          environment and allow microphone access. You will answer {totalQuestions} questions, one at a time, by recording your
+          spoken response. You may pause during recording, but you cannot re-record once finished.
+        </p>
+      </header>
+      <button
+        type="button"
+        onClick={startInterview}
+        className="inline-flex items-center rounded-md bg-indigo-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+      >
+        Begin interview
+      </button>
+    </section>
+  );
+
+  const renderQuestion = () => (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-indigo-500">
+          Question {currentIndex + 1} of {totalQuestions}
+        </p>
+        <h2 className="text-2xl font-semibold text-slate-900">{currentQuestion?.question}</h2>
+        {currentQuestion?.difficulty && (
+          <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+            {currentQuestion.difficulty}
+          </span>
+        )}
+      </header>
+
+      <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-900">Record your response</h3>
+        <p className="text-sm text-slate-600">
+          Press “Start recording” when you are ready. You can pause if needed, then finish to lock in your answer.
+        </p>
+        {recorder.error && <p className="text-sm text-rose-600">{recorder.error}</p>}
+        <RecorderControls
+          isRecording={recorder.isRecording}
+          isPaused={recorder.isPaused}
+          hasRecording={recorder.hasRecording}
+          onStart={recorder.start}
+          onPause={recorder.pause}
+          onResume={recorder.resume}
+          onStop={recorder.stop}
+          disabled={saving}
+        />
+        {recorder.hasRecording && recorder.audioUrl && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-slate-700">Review your recording</p>
+            <audio src={recorder.audioUrl} controls className="w-full" />
+            <p className="text-xs text-slate-500">
+              Once satisfied, continue to transcribe and submit your answer. Re-recording is disabled by design.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {transcriptionMessage && <p className="text-sm text-indigo-600">{transcriptionMessage}</p>}
+      {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleSubmitAnswer}
+          disabled={saving || !recorder.hasRecording}
+          className="inline-flex items-center rounded-md bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {saving ? 'Saving answer...' : 'Submit answer'}
+        </button>
+      </div>
+    </section>
+  );
+
+  const renderComplete = () => (
+    <section className="space-y-6 text-center">
+      <h2 className="text-3xl font-semibold text-slate-900">Thank you!</h2>
+      <p className="text-slate-600">
+        Your responses have been submitted successfully. The hiring team will review your interview shortly.
+      </p>
+    </section>
+  );
+
+  if (step === STEP.LOADING) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Preparing your interview...</h2>
+        <p className="text-slate-600">Please wait while we load the necessary questions.</p>
+      </section>
+    );
+  }
+
+  if (step === STEP.ERROR) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-rose-600">We hit a snag</h2>
+        <p className="text-slate-600">{errorMessage}</p>
+      </section>
+    );
+  }
+
+  if (step === STEP.WELCOME) {
+    return renderWelcome();
+  }
+
+  if (step === STEP.QUESTION) {
+    return renderQuestion();
+  }
+
+  if (step === STEP.COMPLETE) {
+    return renderComplete();
+  }
+
+  return null;
+}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,0 +1,38 @@
+import { Routes, Route } from 'react-router-dom';
+import AppLayout from '../components/AppLayout.jsx';
+import Dashboard from '../pages/Dashboard.jsx';
+import InterviewsPage from '../pages/interviews/InterviewsPage.jsx';
+import InterviewEditorPage from '../pages/interviews/InterviewEditorPage.jsx';
+import QuestionsPage from '../pages/questions/QuestionsPage.jsx';
+import QuestionEditorPage from '../pages/questions/QuestionEditorPage.jsx';
+import ApplicantsPage from '../pages/applicants/ApplicantsPage.jsx';
+import ApplicantEditorPage from '../pages/applicants/ApplicantEditorPage.jsx';
+import TakeInterviewLanding from '../pages/take-interview/TakeInterviewLanding.jsx';
+import NotFound from '../pages/NotFound.jsx';
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<AppLayout />}>
+        <Route index element={<Dashboard />} />
+        <Route path="interviews">
+          <Route index element={<InterviewsPage />} />
+          <Route path="new" element={<InterviewEditorPage />} />
+          <Route path=":id/edit" element={<InterviewEditorPage />} />
+        </Route>
+        <Route path="questions">
+          <Route index element={<QuestionsPage />} />
+          <Route path="new" element={<QuestionEditorPage />} />
+          <Route path=":id/edit" element={<QuestionEditorPage />} />
+        </Route>
+        <Route path="applicants">
+          <Route index element={<ApplicantsPage />} />
+          <Route path="new" element={<ApplicantEditorPage />} />
+          <Route path=":id/edit" element={<ApplicantEditorPage />} />
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </Route>
+      <Route path="/take/:token" element={<TakeInterviewLanding />} />
+    </Routes>
+  );
+}

--- a/src/services/answerApi.js
+++ b/src/services/answerApi.js
@@ -1,0 +1,20 @@
+import { apiClient } from './apiClient.js';
+
+export async function listAnswers(applicantId, { signal } = {}) {
+  return apiClient.get('/answer', {
+    signal,
+    params: applicantId ? { applicant_id: `eq.${applicantId}` } : undefined
+  });
+}
+
+export async function createAnswer(payload, { signal } = {}) {
+  return apiClient.post('/answer', payload, { signal, headers: { Prefer: 'return=representation' } });
+}
+
+export async function updateAnswer(id, payload, { signal } = {}) {
+  return apiClient.patch('/answer', payload, {
+    signal,
+    params: { id: `eq.${id}` },
+    headers: { Prefer: 'return=representation' }
+  });
+}

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,0 +1,90 @@
+const DEFAULT_BASE_URL = 'https://comp2140a2.uqcloud.net/api';
+
+class ApiError extends Error {
+  constructor(message, status, details) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+class ApiClient {
+  constructor({ baseUrl = DEFAULT_BASE_URL } = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  buildUrl(path, params) {
+    const url = new URL(`${this.baseUrl}${path.startsWith('/') ? '' : '/'}${path}`);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === '') return;
+        url.searchParams.append(key, value);
+      });
+    }
+    return url.toString();
+  }
+
+  async request(path, { method = 'GET', params, data, signal, headers } = {}) {
+    const url = this.buildUrl(path, params);
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers
+      },
+      body: data ? JSON.stringify(data) : undefined,
+      signal
+    });
+
+    if (!response.ok) {
+      const details = await this.safeParseJson(response);
+      throw new ApiError(details?.message || response.statusText, response.status, details);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return this.safeParseJson(response);
+  }
+
+  async safeParseJson(response) {
+    const text = await response.text();
+    try {
+      return text ? JSON.parse(text) : null;
+    } catch (error) {
+      return text;
+    }
+  }
+
+  get(path, options) {
+    return this.request(path, { ...options, method: 'GET' });
+  }
+
+  post(path, data, options) {
+    return this.request(path, { ...options, method: 'POST', data });
+  }
+
+  patch(path, data, options) {
+    return this.request(path, { ...options, method: 'PATCH', data });
+  }
+
+  delete(path, options) {
+    return this.request(path, { ...options, method: 'DELETE' });
+  }
+}
+
+export const apiClient = new ApiClient({
+  baseUrl: import.meta.env.VITE_API_BASE_URL || DEFAULT_BASE_URL
+});
+
+export { ApiError, ApiClient };
+
+export function withAbort(signalRef, asyncFn) {
+  const controller = new AbortController();
+  if (signalRef) {
+    signalRef.current = controller;
+  }
+  return asyncFn(controller.signal);
+}

--- a/src/services/applicantApi.js
+++ b/src/services/applicantApi.js
@@ -1,0 +1,33 @@
+import { apiClient } from './apiClient.js';
+
+export async function listApplicants(interviewId, { signal } = {}) {
+  const params = interviewId ? { interview_id: `eq.${interviewId}`, order: 'created_at.desc' } : { order: 'created_at.desc' };
+  return apiClient.get('/applicant', { signal, params });
+}
+
+export async function getApplicant(id, { signal } = {}) {
+  return apiClient.get('/applicant', { signal, params: { id: `eq.${id}` } });
+}
+
+export async function findApplicantByToken(token, { signal } = {}) {
+  if (!token) {
+    throw new Error('Applicant token is required');
+  }
+  const params = {
+    or: `invite_token.eq.${token},token.eq.${token},link_token.eq.${token},access_token.eq.${token}`,
+    limit: 1
+  };
+  return apiClient.get('/applicant', { signal, params });
+}
+
+export async function createApplicant(payload, { signal } = {}) {
+  return apiClient.post('/applicant', payload, { signal, headers: { Prefer: 'return=representation' } });
+}
+
+export async function updateApplicant(id, payload, { signal } = {}) {
+  return apiClient.patch('/applicant', payload, {
+    signal,
+    params: { id: `eq.${id}` },
+    headers: { Prefer: 'return=representation' }
+  });
+}

--- a/src/services/genAiApi.js
+++ b/src/services/genAiApi.js
@@ -1,0 +1,25 @@
+const AI_PLACEHOLDER_DELAY = 800;
+
+export async function generateApplicantSummary({ applicant, answers }) {
+  const apiKey = import.meta.env.VITE_LLM_API_KEY;
+  if (!applicant) {
+    throw new Error('Applicant details are required');
+  }
+
+  // TODO: Replace this placeholder with a call to the production LLM endpoint once available.
+  await new Promise((resolve) => setTimeout(resolve, AI_PLACEHOLDER_DELAY));
+
+  if (!apiKey) {
+    return `AI summary placeholder for ${applicant.firstname} ${applicant.surname}.\n` +
+      'Provide a valid VITE_LLM_API_KEY to enable real LLM-powered insights.';
+  }
+
+  const answerHighlights = (answers || [])
+    .map((answer, index) => `Q${index + 1}: ${answer.transcript?.slice(0, 140) || 'No transcript yet.'}`)
+    .join('\n');
+
+  return `AI Summary (simulated) for ${applicant.firstname} ${applicant.surname}:\n` +
+    `Role: ${applicant.job_role || 'Unknown role'}\n` +
+    `Key takeaways:\n${answerHighlights}\n` +
+    'TODO: Replace with actual LLM response.';
+}

--- a/src/services/interviewApi.js
+++ b/src/services/interviewApi.js
@@ -1,0 +1,25 @@
+import { apiClient } from './apiClient.js';
+
+export async function listInterviews({ signal } = {}) {
+  return apiClient.get('/interview', { signal, params: { order: 'created_at.desc' } });
+}
+
+export async function getInterview(id, { signal } = {}) {
+  return apiClient.get('/interview', { signal, params: { id: `eq.${id}` } });
+}
+
+export async function createInterview(payload, { signal } = {}) {
+  return apiClient.post('/interview', payload, { signal, headers: { Prefer: 'return=representation' } });
+}
+
+export async function updateInterview(id, payload, { signal } = {}) {
+  return apiClient.patch('/interview', payload, {
+    signal,
+    params: { id: `eq.${id}` },
+    headers: { Prefer: 'return=representation' }
+  });
+}
+
+export async function deleteInterview(id, { signal } = {}) {
+  return apiClient.delete('/interview', { signal, params: { id: `eq.${id}` } });
+}

--- a/src/services/questionApi.js
+++ b/src/services/questionApi.js
@@ -1,0 +1,26 @@
+import { apiClient } from './apiClient.js';
+
+export async function listQuestions(interviewId, { signal } = {}) {
+  const params = interviewId ? { interview_id: `eq.${interviewId}`, order: 'created_at.desc' } : { order: 'created_at.desc' };
+  return apiClient.get('/question', { signal, params });
+}
+
+export async function getQuestion(id, { signal } = {}) {
+  return apiClient.get('/question', { signal, params: { id: `eq.${id}` } });
+}
+
+export async function createQuestion(payload, { signal } = {}) {
+  return apiClient.post('/question', payload, { signal, headers: { Prefer: 'return=representation' } });
+}
+
+export async function updateQuestion(id, payload, { signal } = {}) {
+  return apiClient.patch('/question', payload, {
+    signal,
+    params: { id: `eq.${id}` },
+    headers: { Prefer: 'return=representation' }
+  });
+}
+
+export async function deleteQuestion(id, { signal } = {}) {
+  return apiClient.delete('/question', { signal, params: { id: `eq.${id}` } });
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}

--- a/src/utils/interviewLinks.js
+++ b/src/utils/interviewLinks.js
@@ -1,0 +1,15 @@
+export function generateApplicantToken() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function buildApplicantLink(token) {
+  if (!token) return '';
+  const url = new URL(window.location.href);
+  url.pathname = `/take/${token}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}

--- a/src/utils/transcription.js
+++ b/src/utils/transcription.js
@@ -1,0 +1,12 @@
+/**
+ * Placeholder transcription utility. Replace with Transformers.js or Whisper CLI integration.
+ * @param {Blob} audioBlob
+ * @returns {Promise<string>}
+ */
+export async function transcribeAudio(audioBlob) {
+  if (!audioBlob) {
+    throw new Error('Audio blob is required for transcription');
+  }
+  // TODO: Integrate with actual transcription service.
+  return '[Transcription pending integration with Whisper/Transformers]';
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold Vite + React + Tailwind project structure with navigation layout and documentation/rules
- build centralized API services, CRUD forms, and list pages for interviews, questions, and applicants with unique invite links
- implement candidate take-interview flow with audio recording/transcription placeholder plus AI summary panel driven by env-configured GenAI service

## Testing
- npm install *(fails: 403 Forbidden to registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cc935b09fc8330847f02ea46d4ad47